### PR TITLE
Allow golems to remember where they live

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        maven { url = 'https://files.minecraftforge.net/maven' }
+        maven { url 'https://files.minecraftforge.net/maven' }
         jcenter()
         mavenCentral()
     }
@@ -86,13 +86,20 @@ minecraft {
     }
 }
 
+repositories {
+    maven { url 'https://maven.tehnut.info' }
+}
 dependencies {
     // Specify the version of Minecraft to use, If this is any group other then 'net.minecraft' it is assumed
     // that the dep is a ForgeGradle 'patcher' dependency. And it's patches will be applied.
     // The userdev artifact is a special name and will get all sorts of transformations applied to it.
     minecraft 'net.minecraftforge:forge:1.16.2-33.0.7'
-    compile files("D:\\Tenzin\\Downloads\\Hwyla-forge-1.10.11-B78_1.16.2-api.jar")
 
+    // hwyla_version = "1.10.11-B78_1.16.2"
+    // Compile against the Hwyla API, but do not include it at runtime
+    compileOnly fg.deobf("mcp.mobius.waila:Hwyla:1.10.11-B78_1.16.2:api")
+    // At runtime, use the full Hwyla jar
+    runtimeOnly fg.deobf("mcp.mobius.waila:Hwyla:1.10.11-B78_1.16.2")
 }
 
 // Example for how to get properties into the manifest for reading by the runtime..

--- a/src/main/java/com/commodorethrawn/strawgolem/config/ConfigHandler.java
+++ b/src/main/java/com/commodorethrawn/strawgolem/config/ConfigHandler.java
@@ -29,6 +29,11 @@ public class ConfigHandler {
             StrawgolemConfig.shiverEnabled = ConfigHolder.COMMON_CONFIG.shiverEnabled.get();
             StrawgolemConfig.golemInteract = ConfigHolder.COMMON_CONFIG.golemInteract.get();
             StrawgolemConfig.enableHwyla = ConfigHolder.COMMON_CONFIG.enableHwyla.get();
+
+            StrawgolemConfig.tetherEnabled = ConfigHolder.COMMON_CONFIG.tetherEnabled.get();
+            StrawgolemConfig.temptResetsTether = ConfigHolder.COMMON_CONFIG.tetherToTemptEnabled.get();
+            StrawgolemConfig.tetherMinRange = ConfigHolder.COMMON_CONFIG.tetherRangeMin.get();
+            StrawgolemConfig.tetherMaxRange = ConfigHolder.COMMON_CONFIG.tetherRangeMax.get();
         }
     }
 }

--- a/src/main/java/com/commodorethrawn/strawgolem/config/ConfigHelper.java
+++ b/src/main/java/com/commodorethrawn/strawgolem/config/ConfigHelper.java
@@ -29,6 +29,12 @@ public class ConfigHelper {
         return StrawgolemConfig.golemInteract;
     }
 
+    public static boolean isTetherEnabled() { return StrawgolemConfig.tetherEnabled; }
+    public static boolean doesTemptResetTether() { return StrawgolemConfig.temptResetsTether; }
+
+    public static int getTetherMinRange() { return StrawgolemConfig.tetherMinRange; }
+    public static int getTetherMaxRange() { return StrawgolemConfig.tetherMaxRange; }
+
     public static int getSearchRangeHorizontal() {
         return StrawgolemConfig.searchRangeHorizontal;
     }

--- a/src/main/java/com/commodorethrawn/strawgolem/config/StrawgolemConfig.java
+++ b/src/main/java/com/commodorethrawn/strawgolem/config/StrawgolemConfig.java
@@ -25,6 +25,11 @@ public class StrawgolemConfig {
     static boolean shiverEnabled;
     static boolean golemInteract;
     static boolean enableHwyla;
+    /* Tethering */
+    static boolean tetherEnabled;
+    static boolean temptResetsTether;
+    static int tetherMinRange;
+    static int tetherMaxRange;
     /* Lifespan */
     static int lifespan;
     static boolean rainPenalty;
@@ -46,6 +51,8 @@ public class StrawgolemConfig {
         final ForgeConfigSpec.BooleanValue soundsEnabled, golemInteract, shiverEnabled;
         final ForgeConfigSpec.BooleanValue enableHwyla;
         final ForgeConfigSpec.BooleanValue waterPenalty, rainPenalty, heavyPenalty;
+        final ForgeConfigSpec.BooleanValue tetherEnabled, tetherToTemptEnabled;
+        final ForgeConfigSpec.IntValue tetherRangeMin, tetherRangeMax;
 
         CommonConfig(final ForgeConfigSpec.Builder builder) {
             builder.push("Harvesting");
@@ -70,6 +77,12 @@ public class StrawgolemConfig {
             heavyPenalty = builder.comment("Enable lifespan penalty for carrying a heavy item").define("penaltyHeavy", true);
             rainPenalty = builder.comment("Enable lifespan penalty for being in the rain").define("penaltyRain", true);
             waterPenalty = builder.comment("Enable lifespan penalty for being in the water").define("penaltyWater", true);
+            builder.pop();
+            builder.push("Tether");
+            tetherEnabled = builder.comment("Anchor golems to a spot so they don't wander very far.").define("tetherEnabled", true);
+            tetherToTemptEnabled = builder.comment("Tempting golems with an apple updates their tether location if pulled too far").define("temptResetsTether", false);
+            tetherRangeMin = builder.comment("Range that golems will consider within their tether location").defineInRange("tetherMinRange", 4, 1, 16);
+            tetherRangeMax = builder.comment("Range from tether that will cause golems to turn and run back").defineInRange("tetherMaxRange", 16, 1, 32);
             builder.pop();
             builder.push("Miscellaneous");
             soundsEnabled = builder.comment("Enable/disable golem sounds").define("soundsEnabled", true);

--- a/src/main/java/com/commodorethrawn/strawgolem/entity/EntityStrawGolem.java
+++ b/src/main/java/com/commodorethrawn/strawgolem/entity/EntityStrawGolem.java
@@ -114,6 +114,7 @@ public class EntityStrawGolem extends GolemEntity {
         this.goalSelector.addGoal(++priority, new GolemTemptGoal(this));
         this.goalSelector.addGoal(++priority, new GolemHarvestGoal(this, 0.6D));
         this.goalSelector.addGoal(++priority, new GolemDeliverGoal(this, 0.6D));
+        this.goalSelector.addGoal(++priority, new GolemTetherGoal(this, 0.9D)); // tether is fast
         this.goalSelector.addGoal(++priority, new GolemWanderGoal(this, 0.6D));
         this.goalSelector.addGoal(++priority, new GolemLookAtPlayerGoal(this, 5.0F));
         this.goalSelector.addGoal(++priority, new GolemLookRandomlyGoal(this));

--- a/src/main/java/com/commodorethrawn/strawgolem/entity/EntityStrawGolem.java
+++ b/src/main/java/com/commodorethrawn/strawgolem/entity/EntityStrawGolem.java
@@ -114,7 +114,9 @@ public class EntityStrawGolem extends GolemEntity {
         this.goalSelector.addGoal(++priority, new GolemTemptGoal(this));
         this.goalSelector.addGoal(++priority, new GolemHarvestGoal(this, 0.6D));
         this.goalSelector.addGoal(++priority, new GolemDeliverGoal(this, 0.6D));
-        this.goalSelector.addGoal(++priority, new GolemTetherGoal(this, 0.9D)); // tether is fast
+        if (ConfigHelper.isTetherEnabled()) {
+            this.goalSelector.addGoal(++priority, new GolemTetherGoal(this, 0.9D)); // tether is fast
+        }
         this.goalSelector.addGoal(++priority, new GolemWanderGoal(this, 0.6D));
         this.goalSelector.addGoal(++priority, new GolemLookAtPlayerGoal(this, 5.0F));
         this.goalSelector.addGoal(++priority, new GolemLookRandomlyGoal(this));

--- a/src/main/java/com/commodorethrawn/strawgolem/entity/ai/GolemTemptGoal.java
+++ b/src/main/java/com/commodorethrawn/strawgolem/entity/ai/GolemTemptGoal.java
@@ -1,10 +1,12 @@
 package com.commodorethrawn.strawgolem.entity.ai;
 
+import com.commodorethrawn.strawgolem.Strawgolem;
 import com.commodorethrawn.strawgolem.config.ConfigHelper;
 import com.commodorethrawn.strawgolem.entity.EntityStrawGolem;
 import net.minecraft.entity.ai.goal.TemptGoal;
 import net.minecraft.item.Items;
 import net.minecraft.item.crafting.Ingredient;
+import net.minecraft.util.math.BlockPos;
 
 public class GolemTemptGoal extends TemptGoal {
 
@@ -19,5 +21,18 @@ public class GolemTemptGoal extends TemptGoal {
     public void startExecuting() {
         super.startExecuting();
         if (ConfigHelper.isSoundsEnabled()) strawGolem.playSound(EntityStrawGolem.GOLEM_INTERESTED, 1.0F, 1.0F);
+    }
+
+    @Override
+    public void tick() {
+        super.tick();
+        if (ConfigHelper.isTetherEnabled() && ConfigHelper.doesTemptResetTether()) {
+            BlockPos golemPos = strawGolem.getPosition();
+            double d = golemPos.manhattanDistance(strawGolem.getMemory().getAnchorPos());
+            if (d > ConfigHelper.getTetherMaxRange()) {
+                Strawgolem.logger.debug(strawGolem.getEntityId() + " setting new anchor " + golemPos);
+                strawGolem.getMemory().setAnchorPos(golemPos);
+            }
+        }
     }
 }

--- a/src/main/java/com/commodorethrawn/strawgolem/entity/ai/GolemTetherGoal.java
+++ b/src/main/java/com/commodorethrawn/strawgolem/entity/ai/GolemTetherGoal.java
@@ -1,0 +1,94 @@
+package com.commodorethrawn.strawgolem.entity.ai;
+
+import com.commodorethrawn.strawgolem.Strawgolem;
+import com.commodorethrawn.strawgolem.config.ConfigHelper;
+import com.commodorethrawn.strawgolem.entity.EntityStrawGolem;
+import net.minecraft.block.Blocks;
+import net.minecraft.client.particle.HeartParticle;
+import net.minecraft.client.particle.SpellParticle;
+import net.minecraft.entity.ai.goal.MoveToBlockGoal;
+import net.minecraft.entity.ai.goal.WaterAvoidingRandomWalkingGoal;
+import net.minecraft.particles.ParticleTypes;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.vector.Vector3i;
+import net.minecraft.world.IWorldReader;
+
+public class GolemTetherGoal extends MoveToBlockGoal {
+    // TODO: populate these from config
+    public static final double TETHER_MAX_RANGE = 24.0;
+    public static final double TETHER_MIN_RANGE = 4.0;
+
+    private final EntityStrawGolem strawGolem;
+
+    public GolemTetherGoal(EntityStrawGolem strawGolem, double speedIn) {
+        super(strawGolem, speedIn, ConfigHelper.getSearchRangeHorizontal(), ConfigHelper.getSearchRangeVertical());
+        this.strawGolem = strawGolem;
+    }
+
+    private double getTetherDistance() {
+        final BlockPos anchor = strawGolem.getMemory().getAnchorPos();
+        final BlockPos golemPos = strawGolem.getPosition();
+        if (anchor == BlockPos.ZERO) {
+            // if anchor is unset, set it
+            Strawgolem.logger.debug( strawGolem.getEntityId() + " has no anchor, setting " + golemPos );
+            strawGolem.getMemory().setAnchorPos( golemPos );
+            return 0.0;
+        } else {
+            return golemPos.manhattanDistance(anchor);
+        }
+    }
+
+    @Override
+    public void startExecuting() {
+        //Strawgolem.logger.debug( strawGolem.getEntityId() + " is starting to run home");
+        if (ConfigHelper.isSoundsEnabled()) strawGolem.playSound(EntityStrawGolem.GOLEM_SCARED, 1.0F, 1.0F);
+        super.startExecuting();
+    }
+
+    @Override
+    public boolean shouldExecute() {
+        final double d = getTetherDistance();
+        if( d > TETHER_MAX_RANGE
+                && super.shouldExecute() ) {
+            //Strawgolem.logger.debug( strawGolem.getEntityId() + " is "+d+" > "+TETHER_MAX_RANGE+", tethering");
+            this.destinationBlock = strawGolem.getMemory().getAnchorPos();
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean shouldContinueExecuting() {
+        final double d = getTetherDistance();
+        if ( d < TETHER_MIN_RANGE ) {
+            //Strawgolem.logger.debug( strawGolem.getEntityId() + " is "+d+" < "+TETHER_MIN_RANGE+", stopped tethering");
+            return false;
+        } else {
+            return super.shouldContinueExecuting();
+        }
+    }
+
+    @Override
+    protected boolean shouldMoveTo(IWorldReader worldIn, BlockPos pos) {
+        return worldIn.getBlockState(pos).getBlock() != Blocks.AIR;
+    }
+
+    @Override
+    public void tick() {
+        this.strawGolem.getLookController().setLookPosition(
+                this.destinationBlock.getX() + 0.5D,
+                this.destinationBlock.getY(),
+                this.destinationBlock.getZ() + 0.5D,
+                10.0F,
+                this.strawGolem.getVerticalFaceSpeed());
+        if (!this.destinationBlock.withinDistance(this.creature.getPositionVec(), this.getTargetDistanceSq())) {
+            ++this.timeoutCounter;
+            if (this.shouldMove()) {
+                this.creature.getNavigator().tryMoveToXYZ(this.destinationBlock.getX() + 0.5D, this.destinationBlock.getY() + 1D, this.destinationBlock.getZ() + 0.5D, movementSpeed);
+            }
+        } else {
+            timeoutCounter = 0;
+        }
+    }
+
+}

--- a/src/main/java/com/commodorethrawn/strawgolem/entity/ai/GolemTetherGoal.java
+++ b/src/main/java/com/commodorethrawn/strawgolem/entity/ai/GolemTetherGoal.java
@@ -14,10 +14,6 @@ import net.minecraft.util.math.vector.Vector3i;
 import net.minecraft.world.IWorldReader;
 
 public class GolemTetherGoal extends MoveToBlockGoal {
-    // TODO: populate these from config
-    public static final double TETHER_MAX_RANGE = 24.0;
-    public static final double TETHER_MIN_RANGE = 4.0;
-
     private final EntityStrawGolem strawGolem;
 
     public GolemTetherGoal(EntityStrawGolem strawGolem, double speedIn) {
@@ -29,7 +25,7 @@ public class GolemTetherGoal extends MoveToBlockGoal {
         final BlockPos anchor = strawGolem.getMemory().getAnchorPos();
         final BlockPos golemPos = strawGolem.getPosition();
         if (anchor == BlockPos.ZERO) {
-            // if anchor is unset, set it
+            // if anchor is unset, this is a new golem, set it
             Strawgolem.logger.debug( strawGolem.getEntityId() + " has no anchor, setting " + golemPos );
             strawGolem.getMemory().setAnchorPos( golemPos );
             return 0.0;
@@ -40,7 +36,6 @@ public class GolemTetherGoal extends MoveToBlockGoal {
 
     @Override
     public void startExecuting() {
-        //Strawgolem.logger.debug( strawGolem.getEntityId() + " is starting to run home");
         if (ConfigHelper.isSoundsEnabled()) strawGolem.playSound(EntityStrawGolem.GOLEM_SCARED, 1.0F, 1.0F);
         super.startExecuting();
     }
@@ -48,9 +43,8 @@ public class GolemTetherGoal extends MoveToBlockGoal {
     @Override
     public boolean shouldExecute() {
         final double d = getTetherDistance();
-        if( d > TETHER_MAX_RANGE
+        if( d > ConfigHelper.getTetherMaxRange()
                 && super.shouldExecute() ) {
-            //Strawgolem.logger.debug( strawGolem.getEntityId() + " is "+d+" > "+TETHER_MAX_RANGE+", tethering");
             this.destinationBlock = strawGolem.getMemory().getAnchorPos();
             return true;
         }
@@ -60,12 +54,8 @@ public class GolemTetherGoal extends MoveToBlockGoal {
     @Override
     public boolean shouldContinueExecuting() {
         final double d = getTetherDistance();
-        if ( d < TETHER_MIN_RANGE ) {
-            //Strawgolem.logger.debug( strawGolem.getEntityId() + " is "+d+" < "+TETHER_MIN_RANGE+", stopped tethering");
-            return false;
-        } else {
-            return super.shouldContinueExecuting();
-        }
+        return d < ConfigHelper.getTetherMinRange()
+                && super.shouldContinueExecuting();
     }
 
     @Override

--- a/src/main/java/com/commodorethrawn/strawgolem/entity/capability/memory/IMemory.java
+++ b/src/main/java/com/commodorethrawn/strawgolem/entity/capability/memory/IMemory.java
@@ -10,7 +10,6 @@ import net.minecraft.world.World;
 import java.util.Set;
 
 public interface IMemory {
-
     /**
      * Returns the set of all remembered chest positions
      * @return the positions
@@ -42,10 +41,20 @@ public interface IMemory {
      */
     BlockPos getPriorityChest();
 
-
     /**
      * Sets the priority chest to pos
      * @param pos
      */
     void setPriorityChest(BlockPos pos);
+
+    /**
+     * @return the anchor location
+     */
+    BlockPos getAnchorPos();
+
+    /**
+     * Sets the anchor position
+     * @param pos
+     */
+    void setAnchorPos(BlockPos pos);
 }

--- a/src/main/java/com/commodorethrawn/strawgolem/entity/capability/memory/Memory.java
+++ b/src/main/java/com/commodorethrawn/strawgolem/entity/capability/memory/Memory.java
@@ -14,11 +14,15 @@ import java.util.Set;
 public class Memory implements IMemory {
 
     private final Set<Pair<RegistryKey<World>, BlockPos>> posList;
+    // location of preferred chest for delivery
     private BlockPos priority;
+    // location of default wander anchor - where do we go when we've wandered enough?
+    private BlockPos anchor;
 
     public Memory() {
         posList = new HashSet<>();
         priority = BlockPos.ZERO;
+        anchor = BlockPos.ZERO;
     }
 
     @Override
@@ -57,10 +61,15 @@ public class Memory implements IMemory {
         return priority;
     }
 
-
     @Override
     public void setPriorityChest(BlockPos pos) {
         priority = pos;
     }
+
+    @Override
+    public BlockPos getAnchorPos() { return anchor; }
+
+    @Override
+    public void setAnchorPos(BlockPos pos) { anchor = pos; }
 
 }

--- a/src/main/java/com/commodorethrawn/strawgolem/entity/capability/memory/MemoryStorage.java
+++ b/src/main/java/com/commodorethrawn/strawgolem/entity/capability/memory/MemoryStorage.java
@@ -34,6 +34,7 @@ public class MemoryStorage implements Capability.IStorage<IMemory> {
         }
         tag.put("positions", tagList);
         tag.put("priority", NBTUtil.writeBlockPos(instance.getPriorityChest()));
+        tag.put("anchor", NBTUtil.writeBlockPos(instance.getAnchorPos()));
         return tag;
     }
 
@@ -53,6 +54,10 @@ public class MemoryStorage implements Capability.IStorage<IMemory> {
         INBT posTag = tag.get("priority");
         if (posTag instanceof CompoundNBT) {
             instance.setPriorityChest(NBTUtil.readBlockPos((CompoundNBT) posTag));
+        }
+        INBT anchorTag = tag.get("anchor");
+        if (anchorTag instanceof CompoundNBT) {
+            instance.setAnchorPos(NBTUtil.readBlockPos((CompoundNBT) anchorTag));
         }
     }
 }

--- a/src/main/java/com/commodorethrawn/strawgolem/events/GolemEventHandler.java
+++ b/src/main/java/com/commodorethrawn/strawgolem/events/GolemEventHandler.java
@@ -2,6 +2,7 @@ package com.commodorethrawn.strawgolem.events;
 
 import com.commodorethrawn.strawgolem.Strawgolem;
 import com.commodorethrawn.strawgolem.entity.EntityStrawGolem;
+import com.commodorethrawn.strawgolem.entity.ai.GolemTetherGoal;
 import com.commodorethrawn.strawgolem.network.MessageLifespan;
 import com.commodorethrawn.strawgolem.network.PacketHandler;
 import net.minecraft.entity.player.PlayerEntity;
@@ -11,6 +12,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.Hand;
 import net.minecraft.util.Util;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.StringTextComponent;
 import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import net.minecraftforge.event.entity.living.LivingAttackEvent;
@@ -80,6 +82,14 @@ public class GolemEventHandler {
                     StringTextComponent message = new StringTextComponent(golem.getDisplayName().getString() + " will now deliver to this chest");
                     event.getPlayer().sendMessage(message, Util.field_240973_b_);
                     player.getPersistentData().remove(GOLEM);
+
+                    // update the golem's anchor if it is very far from the chest
+                    BlockPos golemPos = golem.getPosition();
+                    BlockPos anchorPos = event.getPos();
+                    if (golemPos.manhattanDistance(anchorPos) > GolemTetherGoal.TETHER_MIN_RANGE ) {
+                        Strawgolem.logger.debug(golem.getEntityId() + " setting new anchor " + anchorPos);
+                        golem.getMemory().setAnchorPos(anchorPos);
+                    }
                 }
             }
         }

--- a/src/main/java/com/commodorethrawn/strawgolem/events/GolemEventHandler.java
+++ b/src/main/java/com/commodorethrawn/strawgolem/events/GolemEventHandler.java
@@ -1,6 +1,7 @@
 package com.commodorethrawn.strawgolem.events;
 
 import com.commodorethrawn.strawgolem.Strawgolem;
+import com.commodorethrawn.strawgolem.config.ConfigHelper;
 import com.commodorethrawn.strawgolem.entity.EntityStrawGolem;
 import com.commodorethrawn.strawgolem.entity.ai.GolemTetherGoal;
 import com.commodorethrawn.strawgolem.network.MessageLifespan;
@@ -84,11 +85,13 @@ public class GolemEventHandler {
                     player.getPersistentData().remove(GOLEM);
 
                     // update the golem's anchor if it is very far from the chest
-                    BlockPos golemPos = golem.getPosition();
-                    BlockPos anchorPos = event.getPos();
-                    if (golemPos.manhattanDistance(anchorPos) > GolemTetherGoal.TETHER_MIN_RANGE ) {
-                        Strawgolem.logger.debug(golem.getEntityId() + " setting new anchor " + anchorPos);
-                        golem.getMemory().setAnchorPos(anchorPos);
+                    if (ConfigHelper.isTetherEnabled()) {
+                        BlockPos golemPos = golem.getPosition();
+                        BlockPos anchorPos = event.getPos();
+                        if (golemPos.manhattanDistance(anchorPos) > ConfigHelper.getTetherMinRange()) {
+                            Strawgolem.logger.debug(golem.getEntityId() + " setting new anchor " + anchorPos);
+                            golem.getMemory().setAnchorPos(anchorPos);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This PR makes two changes to the mod:
1. It fixes the manually downloaded Hwyla build dependency to use maven instead.
2. It adds a new tethering AI behavior to the golems.

## Tethering summary
Golems now remember an `anchor` position in addition to their preferred chest. By default, this anchor is set to the golem's original spawn location, and is updated to match their preferred chest when set.

If golems wander too far from their anchor (by default 16m, Manhattan), they will become frightened and run back home for a bit, stopping either when they get within a minimum range (default 4m) of their anchor, or when the flee goal times out. If the goal timed out, they'll likely try to run home again after a bit.

*Note: I experimented with a default anchor range of 24 blocks, but that allowed golems to get just a bit too far away from crops given the default search range, so I think 16 is ideal*

Optionally, golems that are being tempted with an apple can update their anchor position whenever they exceed their max tether range from their previous anchor. This behavior is disabled by default, but depending on user preferences, may be a candidate for switching on by default.